### PR TITLE
Added reCaptcha and Error Page to Contact Form

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -22,11 +22,11 @@
 			</p>
 		</div>
 		<form id="contact-form" action="mail_form.php" method="post">
-			<input type="text" name="f1" placeholder="Name" required="required" data-message="*"/>
+			<input class="input" type="text" name="f1" placeholder="Name" required="required" data-message="*"/>
 			<br/>
-			<input type="text" name="f2" placeholder="Email Address" required="required" data-message="*"/>
+			<input class="input" type="text" name="f2" placeholder="Email Address" required="required" data-message="*"/>
 			<br/>
-			<select id="select_email" name="sendtoemail">
+			<select class="select" id="select_email" name="sendtoemail">
 				<option value="chairman@csh.rit.edu">Chairman</option>
 				<option value="eval@csh.rit.edu">Evaluations</option>
 				<option value="history@csh.rit.edu">History</option>
@@ -34,8 +34,20 @@
 				<option value="webmaster@csh.rit.edu">Webmaster</option>
 			</select>
 			<br/>
-			<textarea rows="5"  name="f3" cols="20" placeholder="Message" required="required" data-message="*"></textarea>
-			<input type="submit" id="submit-button" value="Send"/>
+			<textarea class="textarea" rows="5"  name="f3" cols="20" placeholder="Message" required="required" data-message="*"></textarea>
+			<br/>
+			<?php
+	          require_once('recaptchalib.php');
+	          $publickey = "6LdMJeISAAAAAHnVuAK_3wMCEcOidQ_09yw0h-4a";
+	          echo recaptcha_get_html($publickey);
+	        ?>
+	        <script type="text/javascript"> 
+	        	(function() {
+	        		document.getElementById("recaptcha_response_field").setAttribute("required","required");
+	        	})();
+	        </script>
+	        <br/>
+			<input class="input" type="submit" id="submit-button" value="Send"/>
 		</form>
 	</div>
 </div>

--- a/failure.php
+++ b/failure.php
@@ -1,0 +1,16 @@
+<?php include "header.php"; ?>
+<div id="big" class="title">
+	<div class="wrapper">
+		<h1>
+			Uh-oh!
+		</h1>
+	</div>
+</div>
+<div id="content">
+	<img src="images/sadjr.png" alt="Sad PC Junior" width="274" height="314" class="center"/>
+	<h1 class="center">Failed to send email!</h1>
+	<p class="center">
+		Something went wrong. Please try again!
+	</p>
+</div>
+<?php include "footer.php"; ?>

--- a/mail_form.php
+++ b/mail_form.php
@@ -1,4 +1,6 @@
 <?php
+	require_once('recaptchalib.php');
+
 	$EMAIL_ADDRESSES = 
 		array(
 			"chairman@csh.rit.edu",
@@ -21,10 +23,23 @@
 
 	// Validate email, this is probably less than great
 	$email = filter_var($email, FILTER_VALIDATE_EMAIL);
-	if (!email) {
+	if (!$email) {
 		header("Location: failure.php");
 		exit;
 	}
+
+	// Run reCAPTCHA validation
+	$privatekey = "6LdMJeISAAAAACVSv8XpbNPCBNlxgxYytXoG15nY";
+	$capchaResponse = $_POST["recaptcha_response_field"];
+	if (!$capchaResponse) {
+		header("Location: failure.php");
+		exit;
+	}
+    $resp = recaptcha_check_answer($privatekey, $_SERVER["REMOTE_ADDR"], $_POST["recaptcha_challenge_field"], $_POST["recaptcha_response_field"]);
+    if (!$resp->is_valid) {
+		header("Location: failure.php");
+		exit;
+    }
 
 	$message = $_POST['f3'];
 	$formcontent="From: $name \nEmail: $email \nMessage: $message";

--- a/pages.css
+++ b/pages.css
@@ -329,25 +329,25 @@ img.membership#second{
 	width:380px;
 	position:relative;
 }
-#contact-form input, #contact-form select, #contact-form textarea {
+#contact-form input.input, #contact-form select.select, #contact-form textarea.textarea {
 	background-color:rgba(0,0,0,.8);
 	line-height:30px;
 	height:30px;
 	padding-left:8px;
 	margin-bottom:20px;
 }
-#contact-form input {
+#contact-form input.input {
 	width:372px;
 	color:white;
 }
-#contact-form textarea {
+#contact-form textarea.textarea {
 	font-family: 'Oxygen', sans-serif;
 	width:372px;
 	height:150px;
 	margin:0;
 	color:white;
 }
-#contact-form select {
+#contact-form select.select {
 	background-color:#323232;
 }
 #select_email{
@@ -358,7 +358,7 @@ img.membership#second{
 	color:#fff;
 	margin:0;
 }
-input#submit-button {
+input.input#submit-button {
 	position:absolute;
 	bottom:-10px;
 	right:-15px;
@@ -369,7 +369,7 @@ input#submit-button {
 	cursor:pointer;
 	margin:0;
 }
-input#submit-button:hover {
+input.input#submit-button:hover {
 	background-color:#498211;
 }
 .error{

--- a/recaptcha-license
+++ b/recaptcha-license
@@ -1,0 +1,22 @@
+Copyright (c) 2007 reCAPTCHA -- http://recaptcha.net
+AUTHORS:
+  Mike Crawford
+  Ben Maurer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/recaptchalib.php
+++ b/recaptchalib.php
@@ -1,0 +1,277 @@
+<?php
+/*
+ * This is a PHP library that handles calling reCAPTCHA.
+ *    - Documentation and latest version
+ *          http://recaptcha.net/plugins/php/
+ *    - Get a reCAPTCHA API Key
+ *          https://www.google.com/recaptcha/admin/create
+ *    - Discussion group
+ *          http://groups.google.com/group/recaptcha
+ *
+ * Copyright (c) 2007 reCAPTCHA -- http://recaptcha.net
+ * AUTHORS:
+ *   Mike Crawford
+ *   Ben Maurer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * The reCAPTCHA server URL's
+ */
+define("RECAPTCHA_API_SERVER", "http://www.google.com/recaptcha/api");
+define("RECAPTCHA_API_SECURE_SERVER", "https://www.google.com/recaptcha/api");
+define("RECAPTCHA_VERIFY_SERVER", "www.google.com");
+
+/**
+ * Encodes the given data into a query string format
+ * @param $data - array of string elements to be encoded
+ * @return string - encoded request
+ */
+function _recaptcha_qsencode ($data) {
+        $req = "";
+        foreach ( $data as $key => $value )
+                $req .= $key . '=' . urlencode( stripslashes($value) ) . '&';
+
+        // Cut the last '&'
+        $req=substr($req,0,strlen($req)-1);
+        return $req;
+}
+
+
+
+/**
+ * Submits an HTTP POST to a reCAPTCHA server
+ * @param string $host
+ * @param string $path
+ * @param array $data
+ * @param int port
+ * @return array response
+ */
+function _recaptcha_http_post($host, $path, $data, $port = 80) {
+
+        $req = _recaptcha_qsencode ($data);
+
+        $http_request  = "POST $path HTTP/1.0\r\n";
+        $http_request .= "Host: $host\r\n";
+        $http_request .= "Content-Type: application/x-www-form-urlencoded;\r\n";
+        $http_request .= "Content-Length: " . strlen($req) . "\r\n";
+        $http_request .= "User-Agent: reCAPTCHA/PHP\r\n";
+        $http_request .= "\r\n";
+        $http_request .= $req;
+
+        $response = '';
+        if( false == ( $fs = @fsockopen($host, $port, $errno, $errstr, 10) ) ) {
+                die ('Could not open socket');
+        }
+
+        fwrite($fs, $http_request);
+
+        while ( !feof($fs) )
+                $response .= fgets($fs, 1160); // One TCP-IP packet
+        fclose($fs);
+        $response = explode("\r\n\r\n", $response, 2);
+
+        return $response;
+}
+
+
+
+/**
+ * Gets the challenge HTML (javascript and non-javascript version).
+ * This is called from the browser, and the resulting reCAPTCHA HTML widget
+ * is embedded within the HTML form it was called from.
+ * @param string $pubkey A public key for reCAPTCHA
+ * @param string $error The error given by reCAPTCHA (optional, default is null)
+ * @param boolean $use_ssl Should the request be made over ssl? (optional, default is false)
+
+ * @return string - The HTML to be embedded in the user's form.
+ */
+function recaptcha_get_html ($pubkey, $error = null, $use_ssl = false)
+{
+	if ($pubkey == null || $pubkey == '') {
+		die ("To use reCAPTCHA you must get an API key from <a href='https://www.google.com/recaptcha/admin/create'>https://www.google.com/recaptcha/admin/create</a>");
+	}
+	
+	if ($use_ssl) {
+                $server = RECAPTCHA_API_SECURE_SERVER;
+        } else {
+                $server = RECAPTCHA_API_SERVER;
+        }
+
+        $errorpart = "";
+        if ($error) {
+           $errorpart = "&amp;error=" . $error;
+        }
+        return '<script type="text/javascript" src="'. $server . '/challenge?k=' . $pubkey . $errorpart . '"></script>
+
+	<noscript>
+  		<iframe src="'. $server . '/noscript?k=' . $pubkey . $errorpart . '" height="300" width="500" frameborder="0"></iframe><br/>
+  		<textarea name="recaptcha_challenge_field" rows="3" cols="40"></textarea>
+  		<input type="hidden" name="recaptcha_response_field" value="manual_challenge"/>
+	</noscript>';
+}
+
+
+
+
+/**
+ * A ReCaptchaResponse is returned from recaptcha_check_answer()
+ */
+class ReCaptchaResponse {
+        var $is_valid;
+        var $error;
+}
+
+
+/**
+  * Calls an HTTP POST function to verify if the user's guess was correct
+  * @param string $privkey
+  * @param string $remoteip
+  * @param string $challenge
+  * @param string $response
+  * @param array $extra_params an array of extra variables to post to the server
+  * @return ReCaptchaResponse
+  */
+function recaptcha_check_answer ($privkey, $remoteip, $challenge, $response, $extra_params = array())
+{
+	if ($privkey == null || $privkey == '') {
+		die ("To use reCAPTCHA you must get an API key from <a href='https://www.google.com/recaptcha/admin/create'>https://www.google.com/recaptcha/admin/create</a>");
+	}
+
+	if ($remoteip == null || $remoteip == '') {
+		die ("For security reasons, you must pass the remote ip to reCAPTCHA");
+	}
+
+	
+	
+        //discard spam submissions
+        if ($challenge == null || strlen($challenge) == 0 || $response == null || strlen($response) == 0) {
+                $recaptcha_response = new ReCaptchaResponse();
+                $recaptcha_response->is_valid = false;
+                $recaptcha_response->error = 'incorrect-captcha-sol';
+                return $recaptcha_response;
+        }
+
+        $response = _recaptcha_http_post (RECAPTCHA_VERIFY_SERVER, "/recaptcha/api/verify",
+                                          array (
+                                                 'privatekey' => $privkey,
+                                                 'remoteip' => $remoteip,
+                                                 'challenge' => $challenge,
+                                                 'response' => $response
+                                                 ) + $extra_params
+                                          );
+
+        $answers = explode ("\n", $response [1]);
+        $recaptcha_response = new ReCaptchaResponse();
+
+        if (trim ($answers [0]) == 'true') {
+                $recaptcha_response->is_valid = true;
+        }
+        else {
+                $recaptcha_response->is_valid = false;
+                $recaptcha_response->error = $answers [1];
+        }
+        return $recaptcha_response;
+
+}
+
+/**
+ * gets a URL where the user can sign up for reCAPTCHA. If your application
+ * has a configuration page where you enter a key, you should provide a link
+ * using this function.
+ * @param string $domain The domain where the page is hosted
+ * @param string $appname The name of your application
+ */
+function recaptcha_get_signup_url ($domain = null, $appname = null) {
+	return "https://www.google.com/recaptcha/admin/create?" .  _recaptcha_qsencode (array ('domains' => $domain, 'app' => $appname));
+}
+
+function _recaptcha_aes_pad($val) {
+	$block_size = 16;
+	$numpad = $block_size - (strlen ($val) % $block_size);
+	return str_pad($val, strlen ($val) + $numpad, chr($numpad));
+}
+
+/* Mailhide related code */
+
+function _recaptcha_aes_encrypt($val,$ky) {
+	if (! function_exists ("mcrypt_encrypt")) {
+		die ("To use reCAPTCHA Mailhide, you need to have the mcrypt php module installed.");
+	}
+	$mode=MCRYPT_MODE_CBC;   
+	$enc=MCRYPT_RIJNDAEL_128;
+	$val=_recaptcha_aes_pad($val);
+	return mcrypt_encrypt($enc, $ky, $val, $mode, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+}
+
+
+function _recaptcha_mailhide_urlbase64 ($x) {
+	return strtr(base64_encode ($x), '+/', '-_');
+}
+
+/* gets the reCAPTCHA Mailhide url for a given email, public key and private key */
+function recaptcha_mailhide_url($pubkey, $privkey, $email) {
+	if ($pubkey == '' || $pubkey == null || $privkey == "" || $privkey == null) {
+		die ("To use reCAPTCHA Mailhide, you have to sign up for a public and private key, " .
+		     "you can do so at <a href='http://www.google.com/recaptcha/mailhide/apikey'>http://www.google.com/recaptcha/mailhide/apikey</a>");
+	}
+	
+
+	$ky = pack('H*', $privkey);
+	$cryptmail = _recaptcha_aes_encrypt ($email, $ky);
+	
+	return "http://www.google.com/recaptcha/mailhide/d?k=" . $pubkey . "&c=" . _recaptcha_mailhide_urlbase64 ($cryptmail);
+}
+
+/**
+ * gets the parts of the email to expose to the user.
+ * eg, given johndoe@example,com return ["john", "example.com"].
+ * the email is then displayed as john...@example.com
+ */
+function _recaptcha_mailhide_email_parts ($email) {
+	$arr = preg_split("/@/", $email );
+
+	if (strlen ($arr[0]) <= 4) {
+		$arr[0] = substr ($arr[0], 0, 1);
+	} else if (strlen ($arr[0]) <= 6) {
+		$arr[0] = substr ($arr[0], 0, 3);
+	} else {
+		$arr[0] = substr ($arr[0], 0, 4);
+	}
+	return $arr;
+}
+
+/**
+ * Gets html to display an email address given a public an private key.
+ * to get a key, go to:
+ *
+ * http://www.google.com/recaptcha/mailhide/apikey
+ */
+function recaptcha_mailhide_html($pubkey, $privkey, $email) {
+	$emailparts = _recaptcha_mailhide_email_parts ($email);
+	$url = recaptcha_mailhide_url ($pubkey, $privkey, $email);
+	
+	return htmlentities($emailparts[0]) . "<a href='" . htmlentities ($url) .
+		"' onclick=\"window.open('" . htmlentities ($url) . "', '', 'toolbar=0,scrollbars=0,location=0,statusbar=0,menubar=0,resizable=0,width=500,height=300'); return false;\" title=\"Reveal this e-mail address\">...</a>@" . htmlentities ($emailparts [1]);
+
+}
+
+
+?>


### PR DESCRIPTION
Spam was still a problem in the contact form, so at the request of the RTPs I added a CAPTCHA to the form. Right now it's a reCaptcha, default red theme. They have a few other built-in themes you can check out that'll probably look better. 

I changed some of the CSS as well (added classes for each input type in the contact form, instead of applying styles directly to the elements) to prevent the reCaptcha from looking like total garbage. It still has some artifacts (hooray table design!), but it's better than it was.

Also, I added the "failure.php" error page for the contact form, since I never actually submitted it after Will finished securing the mail form.
